### PR TITLE
Update to version 0.1.0 with import, export, search, and writing stat…

### DIFF
--- a/com.github.kmwallio.thiefmd.json
+++ b/com.github.kmwallio.thiefmd.json
@@ -31,13 +31,11 @@
   "modules":[
     {
       "name": "gtksourceview",
-      "config-opts": [
-        "--disable-gtk-doc"
-      ],
+      "buildsystem": "meson",
       "sources": [{
         "type": "archive",
-        "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.11.tar.xz",
-        "sha256": "691b074a37b2a307f7f48edc5b8c7afa7301709be56378ccf9cc9735909077fd"
+        "url": "https://download.gnome.org/sources/gtksourceview/4.7/gtksourceview-4.7.90.tar.xz",
+        "sha256": "983bdcb88f98285b3b997c9335057c8fbc45aad0a7c13cb65eb365567e26baaf"
       }]
     },
     {
@@ -96,8 +94,8 @@
       "sources":[
         {
           "type":"archive",
-          "url":"https://github.com/kmwallio/ThiefMD/releases/download/v0.0.12-luminance/com.github.kmwallio.thiefmd-0.0.12.tar.xz",
-          "sha256": "bac67bcf5680f871d236c58aada7326a2a09ad875d1e2b9b412418bee4aaf9b2"
+          "url":"https://github.com/kmwallio/ThiefMD/releases/download/v0.1.0-inandout/com.github.kmwallio.thiefmd-0.1.0.tar.xz",
+          "sha256": "726a1ef437fe74b14287eefcd1dc0343f1827ba7f7553f6663395dc4b72df68e"
         }
       ]
     }


### PR DESCRIPTION
Export Themes and Paper options are here! Customize the Preview CSS, ePub CSS, and PDF CSS.

Whether you need [dark mode preview](https://themes.thiefmd.com/2020/10/07/preview-inverted), are looking to match your site, or need that special touch for your ePub, ThiefMD has you covered.

ThiefMD can now even import your (or someone else's) existing work! Just drag and drop a file into a folder in the Library. If it's compatible, ThiefMD will convert it to Markdown. Results may vary, and they may even be very cool.

* Change the CSS Applied to your ePub
* Pick a different Preview CSS
* New Export Window with more options and more accurate rendering
* Change PDF CSS
* Change PDF Paper Size
* Import ePUB, DocX, HTML, and [more](https://pandoc.org). It's Pandoc under the hoods with a little thievery sprinkled on top
* Editor Search `Ctrl+F` and Library Search `Ctrl+Shift+F`
* [Writing Statistics](https://thiefmd.com/deets/#writing-statistics) `Ctrl+Shift+S` or Right-Click on a Library Item