### PR TITLE
Update to latest ThiefMD with new UI

### DIFF
--- a/com.github.kmwallio.thiefmd.json
+++ b/com.github.kmwallio.thiefmd.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.kmwallio.thiefmd",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.kmwallio.thiefmd",
     "finish-args": [
@@ -40,6 +40,7 @@
                 "sha256": "c30019506320ca2474d834cced1e2217ea533e00eb2a3f4eb7879007940ec682"
             }]
         },
+        "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "gtkspell",
             "cleanup": [
@@ -49,20 +50,7 @@
                 "type": "archive",
                 "url": "https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz",
                 "sha256": "b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732"
-            }],
-            "modules": [{
-                    "name": "enchant",
-                    "cleanup": [
-                        "*.a"
-                    ],
-                    "sources": [{
-                        "type": "archive",
-                        "url": "https://github.com/AbiWord/enchant/releases/download/v2.2.11/enchant-2.2.11.tar.gz",
-                        "sha256": "a29c5777c4e45fcac2595c15c49d6d2aa434fa5e7c993dff3f9f367b65fe472a"
-                    }]
-                },
-                "shared-modules/intltool/intltool-0.51.json"
-            ]
+            }]
         },
         {
             "name": "discount",
@@ -185,9 +173,10 @@
             ],
             "buildsystem": "meson",
             "sources": [{
-                "type": "archive",
-                "url": "https://github.com/kmwallio/ThiefMD/releases/download/v0.2.6/com.github.kmwallio.thiefmd-0.2.6.tar.xz",
-                "sha256": "2128114c86fb4c0df3b08697450b2a6b204483ec7247724bb88f2f48fed1a270"
+                "type": "git",
+                "url": "https://github.com/kmwallio/ThiefMD.git",
+                "tag": "v0.2.7",
+                "commit": "e654b302ce3d0945455bc923caac55967a9fda4e"
             }]
         }
     ]

--- a/com.github.kmwallio.thiefmd.json
+++ b/com.github.kmwallio.thiefmd.json
@@ -83,8 +83,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-amd64.tar.gz",
-                "sha256": "103df36dc21081b7205d763ef7705e340eb0ea7e18694239b328a549892cc007"
+                "url": "https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-linux-amd64.tar.gz",
+                "sha256": "4e1c607f7e4e9243fa1e1f5b208cd4f1d3f6fd055d5d8c39ba0cdc38644e1c35"
             }]
         },
         {
@@ -101,8 +101,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-linux-arm64.tar.gz",
-                "sha256": "a48160539c27c6a35413667b064f9af154d59ad592563dcaab8a07d427bda594"
+                "url": "https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-linux-arm64.tar.gz",
+                "sha256": "8ac04ce0aedae38f0c9f64bfe634910378cc326d091092395a2140a7ec819d54"
             }]
         },
         {


### PR DESCRIPTION
Ever want to just open a Markdown or Fountain file in ThiefMD without importing into the library? Now you can.

Confused on what to do first when opening ThiefMD? Our new Library-less launch window is hopefully clearer.

![image](https://github.com/kmwallio/ThiefMD/assets/132455/91534076-e713-4b8a-b354-45035c53381b)

There's a lot of changes under the hood. We now use the Wordpress REST API instead of XML-RPC. libsoup3 and Webkit2GTK 4.1 power network connections and previews. We're now build on the GNOME 44 SDK.