### PR TITLE
Update to v0.3.0 GTK4 based release

### DIFF
--- a/com.github.kmwallio.thiefmd.json
+++ b/com.github.kmwallio.thiefmd.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.kmwallio.thiefmd",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "com.github.kmwallio.thiefmd",
     "finish-args": [
@@ -36,20 +36,25 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://download.gnome.org/sources/gtksourceview/4.8/gtksourceview-4.8.4.tar.xz",
-                "sha256": "7ec9d18fb283d1f84a3a3eff3b7a72b09a10c9c006597b3fbabbb5958420a87d"
+                "url": "https://download.gnome.org/sources/gtksourceview/5.14/gtksourceview-5.14.2.tar.xz",
+                "sha256": "1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264"
             }]
         },
         "shared-modules/intltool/intltool-0.51.json",
         {
-            "name": "gtkspell",
+            "name": "libspelling",
             "cleanup": [
                 "*.a"
             ],
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Dintrospection=enabled",
+                "-Dvapi=true"
+            ],
             "sources": [{
-                "type": "archive",
-                "url": "https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz",
-                "sha256": "b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732"
+                "type": "git",
+                "url": "https://gitlab.gnome.org/GNOME/libspelling.git",
+                "tag": "0.4.10"
             }]
         },
         {
@@ -65,8 +70,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "http://www.pell.portland.or.us/~orc/Code/discount/discount-2.2.7b.tar.bz2",
-                "sha256": "b9368cc2063831635f9e790d0c4c338c2b4b72658cdc244323241bfcddf6ffd5"
+                "url": "https://www.pell.portland.or.us/~orc/Code/discount/discount-2.2.7e.tar.bz2",
+                "sha256": "82249a3d50a09aac29245990bf9c6139c0ae48707b7dab1268daf851f9db963b"
             }]
         },
         {
@@ -83,8 +88,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-linux-amd64.tar.gz",
-                "sha256": "4e1c607f7e4e9243fa1e1f5b208cd4f1d3f6fd055d5d8c39ba0cdc38644e1c35"
+                "url": "https://github.com/jgm/pandoc/releases/download/3.1.12/pandoc-3.1.12-linux-amd64.tar.gz",
+                "sha256": "e30d20cc3f9aefa117bf2183fe74cfc7cb043237d56eb63272b82bf76b537991"
             }]
         },
         {
@@ -101,8 +106,8 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://github.com/jgm/pandoc/releases/download/3.1.2/pandoc-3.1.2-linux-arm64.tar.gz",
-                "sha256": "8ac04ce0aedae38f0c9f64bfe634910378cc326d091092395a2140a7ec819d54"
+                "url": "https://github.com/jgm/pandoc/releases/download/3.1.12/pandoc-3.1.12-linux-arm64.tar.gz",
+                "sha256": "5e27952bee7ddc88e5629bf86252233b418abdf8f7f66c86c412805469afd560"
             }]
         },
         {
@@ -117,14 +122,13 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://github.com/opencog/link-grammar/archive/refs/tags/link-grammar-5.10.5.tar.gz",
-                    "sha256" : "523182a1c77bd41b1bc4ab56ead2b0e7e6bec42e1af9a55c225fbacecd81c416"
+                    "url" : "https://github.com/opencog/link-grammar/archive/refs/tags/link-grammar-5.13.0.tar.gz",
+                    "sha256" : "a545b7efb7aceab2d8ad301466f199778a3da712928999ed8d66deb32ca3184f"
                 }
             ]
         },
-        "shared-modules/libsecret/libsecret.json",
         {
-            "name" : "libhandy",
+            "name" : "libadwaita",
             "buildsystem" : "meson",
             "cleanup": [
                 "*.a"
@@ -132,7 +136,6 @@
             "config-opts" : [
                 "-Dexamples=false",
                 "-Dprofiling=false",
-                "-Dglade_catalog=disabled",
                 "-Dintrospection=enabled",
                 "-Dtests=false",
                 "-Dvapi=true"
@@ -140,8 +143,8 @@
             "sources" : [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/libhandy/1.6/libhandy-1.6.2.tar.xz",
-                    "sha256": "7fa89aaa87966b6d0f5f4ef4d3efdaf654e2b01ea2c7ce2bd70301d1f9f42ca3"
+                    "url": "https://download.gnome.org/sources/libadwaita/1.6/libadwaita-1.6.2.tar.xz",
+                    "sha256": "7542f8354e6808dd4e9a31551bbdfc0170735e4af4d1b3e69186500ccb9c01eb"
                 }
             ]
         },
@@ -176,8 +179,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/kmwallio/ThiefMD.git",
-                    "tag": "v0.2.7",
-                    "commit": "e654b302ce3d0945455bc923caac55967a9fda4e"
+                    "tag": "v0.3.0",
+                    "commit": "75b8a5632a17af2eb4fb6141048393582ea0b0a7"
                 },
                 {
                     "type": "patch",

--- a/com.github.kmwallio.thiefmd.json
+++ b/com.github.kmwallio.thiefmd.json
@@ -54,7 +54,8 @@
             "sources": [{
                 "type": "git",
                 "url": "https://gitlab.gnome.org/GNOME/libspelling.git",
-                "tag": "0.4.10"
+                "tag": "0.4.10",
+                "commit": "1facdde8e1c0fd72bed806f9a9be2fbec83af5f2"
             }]
         },
         {

--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -1,4 +1,4 @@
-From cd56248d25d328cb4c5b6349315587271da5002d Mon Sep 17 00:00:00 2001
+From 75b8a5632a17af2eb4fb6141048393582ea0b0a7 Mon Feb 16 00:00:00 2001
 From: Sabri Ünal <yakushabb@gmail.com>
 Date: Sat, 16 Nov 2024 19:50:52 +0300
 Subject: [PATCH] Fix appdata papercuts
@@ -11,7 +11,7 @@ diff --git a/data/com.github.kmwallio.thiefmd.appdata.xml b/data/com.github.kmwa
 index bfaf041..9a5dd1f 100644
 --- a/data/com.github.kmwallio.thiefmd.appdata.xml
 +++ b/data/com.github.kmwallio.thiefmd.appdata.xml
-@@ -75,8 +75,8 @@
+@@ -80,8 +80,8 @@
      <release version="0.2.7" date="2023-06-03" urgency="low">
        <description>
          <p>Like your files to fly solo? Open files from your file manager. Even abandon our library concept if you want to.</p>

--- a/python3-weasyprint.json
+++ b/python3-weasyprint.json
@@ -2,13 +2,14 @@
     "name": "python3-weasyprint",
     "buildsystem": "simple",
     "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pybind11\" --no-build-isolation",
         "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"weasyprint\" --no-build-isolation"
     ],
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/91/25/ba6f370e18359292f05ca4df93642eb7d1c424721ef61f61b8610a63d0c5/zopfli-0.2.1.zip",
-            "sha256": "e5263d2806e2c1ccb23f52b2972a235d31d42f22f3fa3032cc9aded51e9bf2c6"
+            "url": "https://files.pythonhosted.org/packages/0a/4d/a8cc1768b2eda3c0c7470bf8059dcb94ef96d45dd91fc6edd29430d44072/zopfli-0.4.1.tar.gz",
+            "sha256": "07a5cdc5d1aaa6c288c5d9f5a5383042ba743641abf8e2fd898dcad622d8a38e"
         },
         {
             "type": "file",
@@ -17,43 +18,48 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/43/6e/59853546226ee6200f9ba6e574d11604b60ad0754d2cbd1c8f3246b70418/Pillow-9.1.1.tar.gz",
-            "sha256": "7502539939b53d7565f3d11d87c78e7ec900d3c72945d4ee0e2f250d598309a0"
+            "url": "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz",
+            "sha256": "9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/00/9e/92de7e1217ccc3d5f352ba21e52398372525765b2e0c4530e6eb2ba9282a/cffi-1.15.0.tar.gz",
-            "sha256": "920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"
+            "url": "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz",
+            "sha256": "44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip",
-            "sha256": "4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"
+            "url": "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz",
+            "sha256": "e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/e4/40/98fcfdf1a190aa0aeddf2fd0a432a4997c2c1f826f3f7b00fe42fc72c8ce/cssselect2-0.6.0-py3-none-any.whl",
-            "sha256": "3a83b2a68370c69c9cd3fcb88bbfaebe9d22edeef2c22d1ff3e1ed9c7fa45ed8"
+            "url": "https://files.pythonhosted.org/packages/cd/8a/37362fc2b949d5f733a8b0f2ff51ba423914cabefe69f1d1b6aab710f5fe/pybind11-3.0.1-py3-none-any.whl",
+            "sha256": "aa8f0aa6e0a94d3b64adfc38f560f33f15e589be2175e103c0a33c6bce55ee89"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/53/7b/5dba39bf0572f1f28e2844f08f74a73482a381de1d1feac3bbc6b808051e/tinycss2-1.1.1-py3-none-any.whl",
-            "sha256": "fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8"
+            "url": "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl",
+            "sha256": "6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/89/e1/8e7313c8bf030ab5fc63f6a6b2f037b39fa2858fe1e93d3c06440a4b7614/pyphen-0.12.0-py3-none-any.whl",
-            "sha256": "459020cd320eb200c0c5ba46b98b2278fd34c5546f520fdcd2ce5f8d733eb994"
+            "url": "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl",
+            "sha256": "3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl",
-            "sha256": "8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"
+            "url": "https://files.pythonhosted.org/packages/7b/1f/c2142d2edf833a90728e5cdeb10bdbdc094dde8dbac078cee0cf33f5e11b/pyphen-0.17.2-py3-none-any.whl",
+            "sha256": "3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/2d/e0/91806004db4bcde81325aee95ea37fdc3d01a2a07d407df0a450f9cdaa0c/pydyf-0.2.0-py3-none-any.whl",
-            "sha256": "f0468bc644d3a5b0a7072d0d92bd5c024cf4beede0df56100d9919a59f15e1f0"
+            "url": "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl",
+            "sha256": "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/5c/de/27c57899297163a4a84104d5cec0af3b1ac5faf62f44667e506373c6b8ce/tinyhtml5-2.0.0-py3-none-any.whl",
+            "sha256": "13683277c5b176d070f82d099d977194b7a1e26815b016114f581a74bbfbf47e"
         },
         {
             "type": "file",
@@ -62,13 +68,18 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/2f/85/2f6e42fb4b537b9998835410578fb1973175b81691e9a82ab6668cf64b0b/fonttools-4.33.3-py3-none-any.whl",
-            "sha256": "f829c579a8678fa939a1d9e9894d01941db869de44390adb49ce67055a06cc2a"
+            "url": "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl",
+            "sha256": "17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371"
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/48/a7/ae524a86811012ee4ff72106f209403c7c2e6aa17d05813761b5e8403ab4/weasyprint-55.0-py3-none-any.whl",
-            "sha256": "6a5008b3e1152498f206b2d0791b3e161f507607e31ca42b307cb31b49795462"
+            "url": "https://files.pythonhosted.org/packages/22/11/47efe2f66ba848a107adfd490b508f5c0cedc82127950553dca44d29e6c4/pydyf-0.12.1-py3-none-any.whl",
+            "sha256": "ea25b4e1fe7911195cb57067560daaa266639184e8335365cc3ee5214e7eaadc"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/dd/dd/14eb73cea481ad8162d3b18a4850d4a84d6e804a22840cca207648532265/weasyprint-68.1-py3-none-any.whl",
+            "sha256": "4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be"
         }
     ]
 }


### PR DESCRIPTION
😶‍🌫️ so… it’s been a while.

Thank you to everyone who had kind words to say about our app, and thank you all for your continued support.

This release brings:

- GTK4
- GTKSourceView5
- Webkit2Gtk6
- Ghost 2FA Support
- Hashnode GQL Support
- Enabling always showing file names
- Large file handling improvements

GTK4 migration improves some of the drag and drop handling from other apps, particularly on Wayland. The Library and Sheets panes can be resized.

😅 As part of the migration, we tried to keep all existing features. There might be some UI changes as we changed outdated GTK3 components to their GTK4 counterparts.